### PR TITLE
Fixes issue where the feed id was not adding http to the link

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function feedMetaTags({ title, description, link, copyright, generator, opt }) {
 
     const now = new Date();
     let siteMeta = [
-      { id: link },
+      { id: link.includes('http') ? link : `http://${link}` },
       { title },
       { subtitle: description },
       { link: { _attr: { rel: 'self', href: link } } },

--- a/index.test.js
+++ b/index.test.js
@@ -116,7 +116,7 @@ describe(dirname, function () {
         const [ entryId, entryTitle, entrySubtitle, , , entryRights, entryGenerator ] =
           fn({ title:'foo', description: 'bar', link: 'foobar', copyright: '2018', generator: 'Feed delivered by Clay' })([]);
 
-        expect(entryId.id).to.eql('foobar');
+        expect(entryId.id).to.eql('http://foobar');
         expect(entryTitle.title).to.eql('foo');
         expect(entrySubtitle.subtitle).to.eql('bar');
         expect(entryRights.rights).to.eql('2018');


### PR DESCRIPTION
## Description

- Modified index file to verify whether the feed link has `http` in it or not. If it doesn't then it adds it